### PR TITLE
Fix: close response body

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -159,17 +159,17 @@ func errorHandler(res *http.Response) error {
 func GetRandomString(length int) string {
 	rand.Seed(time.Now().UnixNano())
 	chars := []rune("ABCDEFGHIJKLMNOPQRSTUVEWXYZabcdefghijklmnopqrstuvewxyz0123456789")
-	var bytes strings.Builder
+	var stringBuilder strings.Builder
 	for i := 0; i < length; i++ {
-		bytes.WriteRune(chars[rand.Intn(len(chars))])
+		stringBuilder.WriteRune(chars[rand.Intn(len(chars))])
 	}
 
-	return bytes.String()
+	return stringBuilder.String()
 }
 
 func GetJoinString(values ...string) string {
-	len := len(values)
-	urls := make([]string, len)
+	valuesCount := len(values)
+	urls := make([]string, valuesCount)
 
 	for _, s := range values {
 		urls = append(urls, s)

--- a/util/util.go
+++ b/util/util.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"io/ioutil"
+	"log"
 	"math/rand"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 )
@@ -27,6 +29,12 @@ const (
 	PUT    = "PUT"
 	DELETE = "DELETE"
 )
+
+var logger *log.Logger
+
+func init() {
+	logger = log.New(os.Stderr, "xxx: ", log.Ldate|log.Ltime|log.Lshortfile)
+}
 
 type Method string
 
@@ -96,6 +104,11 @@ func call(client *http.Client, req *http.Request) ([]byte, error) {
 	if err != nil {
 		return []byte{}, err
 	}
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			logger.Printf("res.body.close ", err)
+		}
+	}()
 
 	resBody, err := ioutil.ReadAll(res.Body)
 	if err != nil {


### PR DESCRIPTION
[golang http client do method description](https://pkg.go.dev/net/http#Client.Do) 에 설명되어 있는대로 response body가 not nil이면 반드시 close해줘야 합니다. 이를 defer로 보장하고, close과정에서 예상치 못한 에러가 날 경우 로깅을 시도합니다. 그리고 예약어/package명으로 되어있는 변수 명 수정하였습니다.